### PR TITLE
Magic Desk 2 CRT 2 Mb Support added 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Based on FPGA64 by Peter Wendrich with heavy later modifications by different pe
 - OPL2 sound expander.
 - Pause option when OSD is opened.
 - 4 joysticks mode.
+- Snac DB9 joysticks support (via UserIO) with Autofire
 - RS232 with VIC-1011 and UP9600 modes either internal or through USER_IO.
 - Loadable Kernal/drive ROMs.
 - Special reduced border mode for 16:9 display.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Based on FPGA64 by Peter Wendrich with heavy later modifications by different pe
 - **VIC register $D030 video manipulation tricks** (used in some demos, e.g. RfO part 1)
 - **VDC with 16k or 64k RAM and multiple colour palettes**.
 - Almost all C64 **and C128** cartridge formats (\*.CRT).
+- Added Magic Desk 2 (2 MB) CRT cartridge support (SNK vs Capcom Stronger Edition game)
 - **Internal Function ROM support for ROMs up to 1Mb with MegaBit 128 support**
 - Direct file injection (\*.PRG) **with detection of C128 or C64 mode**.
 - Dual SID with several degree of mixing 6581/8580 from stereo to mono.

--- a/c128.sv
+++ b/c128.sv
@@ -301,6 +301,8 @@ localparam CONF_STR = {
    "P2FC5,CRT,Boot Cartridge              ;",
    "-;",
    "O[3],Swap Joysticks,No,Yes;",
+   "O[104:103],SNAC Joystick,Disabled,Joy 1,Joy 2,Joy 1 + 2;",
+   "O[88:87],SNAC Autofire,Off,Slow,Fast;",
    "-;",
    "O[49:48],8502 Speed,Standard,x2,x3,x4;",
    "HCO[101],Z80 Speed,Standard,x2;",
@@ -445,6 +447,21 @@ end
 
 wire  [15:0] joyA,joyB,joyC,joyD;
 wire  [15:0] joy = joyA | joyB | joyC | joyD;
+wire   [1:0] snac_mode = status[104:103]; // 0=disabled, 1=Joy1, 2=Joy2, 3=Joy+Joy2
+wire         snac_en   = |snac_mode;
+// snac_joy: {fire3=0, fire2, fire1, right, left, down, up} - active high
+wire [6:0] snac_joy  = {1'b0, ~USER_IN[6], ~USER_IN[2], ~USER_IN[3], ~USER_IN[5], ~USER_IN[0], ~USER_IN[1]};
+
+// format: {fire3=0, fireB(Pin9), fireA(Pin6), right(Pin4), left(Pin3), down(Pin2), up(Pin1)}
+
+// SNAC Autofire: oscillatore software, non richiede il +5V hardware (DB9 Pin 5)
+// Fire 1 (DB9 Pin 6) viene modulato; Fire 2 (DB9 Pin 9) passa sempre diretto
+wire [1:0] snac_af_mode = status[88:87];
+reg [21:0] snac_af_cnt;
+always @(posedge clk_sys) snac_af_cnt <= snac_af_cnt + 1'd1;
+// Slow ~7.6 Hz | Fast ~15.3 Hz  (clk_sys = 32 MHz)
+wire snac_af_clk = (snac_af_mode == 2'd2) ? snac_af_cnt[20] : snac_af_cnt[21];
+wire [6:0] snac_joy_af = {snac_joy[6:5], snac_af_mode ? (snac_joy[4] & snac_af_clk) : snac_joy[4], snac_joy[3:0]};
 
 reg          status_set;
 reg          status_in_98;
@@ -793,8 +810,10 @@ wire [6:0] joyC_c64 = joy[9:8] ? 7'd0 : {joyC[6:4], joyC[0], joyC[1], joyC[2], j
 wire [6:0] joyD_c64 = joy[9:8] ? 7'd0 : {joyD[6:4], joyD[0], joyD[1], joyD[2], joyD[3]};
 
 // swap joysticks if requested
-wire [6:0] joyA_c64 = status[3] ? joyB_int : joyA_int;
-wire [6:0] joyB_c64 = status[3] ? joyA_int : joyB_int;
+wire [6:0] joyA_base = status[3] ? joyB_int : joyA_int;
+wire [6:0] joyB_base = status[3] ? joyA_int : joyB_int;
+wire [6:0] joyA_c64  = (snac_mode == 2'd1 || snac_mode == 2'd3) ? snac_joy_af : joyA_base;
+wire [6:0] joyB_c64  = (snac_mode == 2'd2 || snac_mode == 2'd3) ? snac_joy_af : joyB_base;
 
 wire [7:0] paddle_1 = status[3] ? pd3 : pd1;
 wire [7:0] paddle_2 = status[3] ? pd4 : pd2;
@@ -1728,50 +1747,19 @@ end
 
 wire ext_iec_en = status[25];
 
-iec_io iec_io_clk
-(
-   .clk(clk_sys),
-   .ext_en(ext_iec_en),
+wire ext_iec_clk  = |snac_mode ? 1'b1 : (USER_IN[2] | ~ext_iec_en);
+wire ext_iec_data = |snac_mode ? 1'b1 : (USER_IN[4] | ~ext_iec_en);
+wire ext_iec_srq_n = |snac_mode ? 1'b1 : (USER_IN[6] | ~ext_iec_en);
 
-   .cpu_o(c64_iec_clk_o),
-   .drive_o(drive_iec_clk_o),
-   .ext_o(USER_IN[2]),
+assign c64_iec_clk_i = ext_iec_clk;
+assign c64_iec_data_i = ext_iec_data;
+assign c64_iec_srq_n_i = ext_iec_srq_n;
 
-   .cpu_i(c64_iec_clk_i),
-   .drive_i(drive_iec_clk_i),
-   .ext_i(USER_OUT[2])
-);
-
-iec_io iec_io_data
-(
-   .clk(clk_sys),
-   .ext_en(ext_iec_en),
-
-   .cpu_o(c64_iec_data_o),
-   .drive_o(drive_iec_data_o),
-   .ext_o(USER_IN[4]),
-
-   .cpu_i(c64_iec_data_i),
-   .drive_i(drive_iec_data_i),
-   .ext_i(USER_OUT[4])
-);
-
-iec_io iec_io_srq_n
-(
-   .clk(clk_sys),
-   .ext_en(ext_iec_en),
-
-   .cpu_o(c64_iec_srq_n_o),
-   .drive_o(drive_iec_srq_n_o),
-   .ext_o(USER_IN[6]),
-
-   .cpu_i(c64_iec_srq_n_i),
-   .drive_i(drive_iec_srq_n_i),
-   .ext_i(USER_OUT[6])
-);
-
-assign USER_OUT[3] = (reset_n & ~status[6]) | ~ext_iec_en;
-assign USER_OUT[5] = c64_iec_atn | ~ext_iec_en;
+assign USER_OUT[2] = |snac_mode ? 1'b1 : ((c64_iec_clk_o & drive_iec_clk_o) | ~ext_iec_en);
+assign USER_OUT[3] = |snac_mode ? 1'b1 : ((reset_n & ~status[6]) | ~ext_iec_en);
+assign USER_OUT[4] = |snac_mode ? 1'b1 : ((c64_iec_data_o & drive_iec_data_o) | ~ext_iec_en);
+assign USER_OUT[5] = |snac_mode ? 1'b1 : (c64_iec_atn | ~ext_iec_en);
+assign USER_OUT[6] = 1'b1;
 
 wire hblank;
 wire vblank;

--- a/c128.sv
+++ b/c128.sv
@@ -301,8 +301,6 @@ localparam CONF_STR = {
    "P2FC5,CRT,Boot Cartridge              ;",
    "-;",
    "O[3],Swap Joysticks,No,Yes;",
-   "O[104:103],SNAC Joystick,Disabled,Joy 1,Joy 2,Joy 1 + 2;",
-   "O[106:105],SNAC Autofire,Off,Slow,Fast;",
    "-;",
    "O[49:48],8502 Speed,Standard,x2,x3,x4;",
    "HCO[101],Z80 Speed,Standard,x2;",
@@ -447,21 +445,6 @@ end
 
 wire  [15:0] joyA,joyB,joyC,joyD;
 wire  [15:0] joy = joyA | joyB | joyC | joyD;
-wire   [1:0] snac_mode = status[104:103]; // 0=disabled, 1=Joy1, 2=Joy2, 3=Joy+Joy2
-wire         snac_en   = |snac_mode;
-// snac_joy: {fire3=0, fire2, fire1, right, left, down, up} - active high
-wire [6:0] snac_joy  = {1'b0, ~USER_IN[6], ~USER_IN[2], ~USER_IN[3], ~USER_IN[5], ~USER_IN[0], ~USER_IN[1]};
-
-// format: {fire3=0, fireB(Pin9), fireA(Pin6), right(Pin4), left(Pin3), down(Pin2), up(Pin1)}
-
-// SNAC Autofire: oscillatore software, non richiede il +5V hardware (DB9 Pin 5)
-// Fire 1 (DB9 Pin 6) viene modulato; Fire 2 (DB9 Pin 9) passa sempre diretto
-wire [1:0] snac_af_mode = status[106:105];
-reg [21:0] snac_af_cnt;
-always @(posedge clk_sys) snac_af_cnt <= snac_af_cnt + 1'd1;
-// Slow ~7.6 Hz | Fast ~15.3 Hz  (clk_sys = 32 MHz)
-wire snac_af_clk = (snac_af_mode == 2'd2) ? snac_af_cnt[20] : snac_af_cnt[21];
-wire [6:0] snac_joy_af = {snac_joy[6:5], snac_af_mode ? (snac_joy[4] & snac_af_clk) : snac_joy[4], snac_joy[3:0]};
 
 reg          status_set;
 reg          status_in_98;
@@ -810,10 +793,8 @@ wire [6:0] joyC_c64 = joy[9:8] ? 7'd0 : {joyC[6:4], joyC[0], joyC[1], joyC[2], j
 wire [6:0] joyD_c64 = joy[9:8] ? 7'd0 : {joyD[6:4], joyD[0], joyD[1], joyD[2], joyD[3]};
 
 // swap joysticks if requested
-wire [6:0] joyA_base = status[3] ? joyB_int : joyA_int;
-wire [6:0] joyB_base = status[3] ? joyA_int : joyB_int;
-wire [6:0] joyA_c64  = (snac_mode == 2'd1 || snac_mode == 2'd3) ? snac_joy_af : joyA_base;
-wire [6:0] joyB_c64  = (snac_mode == 2'd2 || snac_mode == 2'd3) ? snac_joy_af : joyB_base;
+wire [6:0] joyA_c64 = status[3] ? joyB_int : joyA_int;
+wire [6:0] joyB_c64 = status[3] ? joyA_int : joyB_int;
 
 wire [7:0] paddle_1 = status[3] ? pd3 : pd1;
 wire [7:0] paddle_2 = status[3] ? pd4 : pd2;
@@ -871,7 +852,7 @@ localparam RAM_ADDR = 25'h0000000;  // System RAM: 256k
 localparam CRM_ADDR = 25'h0040000;  // Cartridge RAM: 64k
 localparam ROM_ADDR = 25'h0060000;  // System ROM: 72k (align on 128k)       loaded from boot0.rom or MRA (required)
 localparam DRV_ADDR = 25'h0080000;  // Drive ROM: 512k                       loaded from boot0.rom, boot1.rom or MRA (required)
-localparam CRT_ADDR = 25'h0100000;  // Cartridge: 2M (up 128 banks x 16 KB)  can be loaded from boot0.rom, boot3.rom or MRA (first 32k, optional)
+localparam CRT_ADDR = 25'h0100000;  // Cartridge: up to 2MB (128 x 16KB)     can be loaded from boot0.rom, boot3.rom or MRA (first 32k, optional)
 localparam IFR_ADDR = 25'h0300000;  // Internal function ROM: 1M             can be loaded from boot2.rom or MRA (optional)
 localparam TAP_ADDR = 25'h0400000;  // Tape buffer (not aligned)
 localparam GEO_ADDR = 25'h0C00000;  // GeoRAM: 4M
@@ -1747,21 +1728,50 @@ end
 
 wire ext_iec_en = status[25];
 
-// Gestione IEC wired‑OR (come nel core C64)
-wire ext_iec_clk  = |snac_mode ? 1'b1 : (USER_IN[2] | ~ext_iec_en);
-wire ext_iec_data = |snac_mode ? 1'b1 : (USER_IN[4] | ~ext_iec_en);
-wire ext_iec_srq_n = |snac_mode ? 1'b1 : (USER_IN[6] | ~ext_iec_en);
+iec_io iec_io_clk
+(
+   .clk(clk_sys),
+   .ext_en(ext_iec_en),
 
-assign c64_iec_clk_i   = ext_iec_clk;
-assign c64_iec_data_i  = ext_iec_data;
-assign c64_iec_srq_n_i = ext_iec_srq_n;
+   .cpu_o(c64_iec_clk_o),
+   .drive_o(drive_iec_clk_o),
+   .ext_o(USER_IN[2]),
 
-// Uscite verso i pin USER_OUT: quando SNAC è attivo, disabilitiamo le uscite IEC (1)
-assign USER_OUT[2] = |snac_mode ? 1'b1 : ((c64_iec_clk_o & drive_iec_clk_o) | ~ext_iec_en);
-assign USER_OUT[3] = |snac_mode ? 1'b1 : ((reset_n & ~status[6]) | ~ext_iec_en);
-assign USER_OUT[4] = |snac_mode ? 1'b1 : ((c64_iec_data_o & drive_iec_data_o) | ~ext_iec_en);
-assign USER_OUT[5] = |snac_mode ? 1'b1 : (c64_iec_atn | ~ext_iec_en);
-assign USER_OUT[6] = 1'b1;
+   .cpu_i(c64_iec_clk_i),
+   .drive_i(drive_iec_clk_i),
+   .ext_i(USER_OUT[2])
+);
+
+iec_io iec_io_data
+(
+   .clk(clk_sys),
+   .ext_en(ext_iec_en),
+
+   .cpu_o(c64_iec_data_o),
+   .drive_o(drive_iec_data_o),
+   .ext_o(USER_IN[4]),
+
+   .cpu_i(c64_iec_data_i),
+   .drive_i(drive_iec_data_i),
+   .ext_i(USER_OUT[4])
+);
+
+iec_io iec_io_srq_n
+(
+   .clk(clk_sys),
+   .ext_en(ext_iec_en),
+
+   .cpu_o(c64_iec_srq_n_o),
+   .drive_o(drive_iec_srq_n_o),
+   .ext_o(USER_IN[6]),
+
+   .cpu_i(c64_iec_srq_n_i),
+   .drive_i(drive_iec_srq_n_i),
+   .ext_i(USER_OUT[6])
+);
+
+assign USER_OUT[3] = (reset_n & ~status[6]) | ~ext_iec_en;
+assign USER_OUT[5] = c64_iec_atn | ~ext_iec_en;
 
 wire hblank;
 wire vblank;

--- a/c128.sv
+++ b/c128.sv
@@ -871,9 +871,9 @@ localparam RAM_ADDR = 25'h0000000;  // System RAM: 256k
 localparam CRM_ADDR = 25'h0040000;  // Cartridge RAM: 64k
 localparam ROM_ADDR = 25'h0060000;  // System ROM: 72k (align on 128k)       loaded from boot0.rom or MRA (required)
 localparam DRV_ADDR = 25'h0080000;  // Drive ROM: 512k                       loaded from boot0.rom, boot1.rom or MRA (required)
-localparam CRT_ADDR = 25'h0100000;  // Cartridge: 1M                         can be loaded from boot0.rom, boot3.rom or MRA (first 32k, optional)
-localparam IFR_ADDR = 25'h0200000;  // Internal function ROM: 1M             can be loaded from boot2.rom or MRA (optional)
-localparam TAP_ADDR = 25'h0300000;  // Tape buffer (not aligned)
+localparam CRT_ADDR = 25'h0100000;  // Cartridge: 2M                         can be loaded from boot0.rom, boot3.rom or MRA (first 32k, optional)
+localparam IFR_ADDR = 25'h0300000;  // Internal function ROM: 1M             can be loaded from boot2.rom or MRA (optional)
+localparam TAP_ADDR = 25'h0400000;  // Tape buffer (not aligned)
 localparam GEO_ADDR = 25'h0C00000;  // GeoRAM: 4M
 localparam REU_ADDR = 25'h1000000;  // REU: 16M
 

--- a/c128.sv
+++ b/c128.sv
@@ -871,9 +871,9 @@ localparam RAM_ADDR = 25'h0000000;  // System RAM: 256k
 localparam CRM_ADDR = 25'h0040000;  // Cartridge RAM: 64k
 localparam ROM_ADDR = 25'h0060000;  // System ROM: 72k (align on 128k)       loaded from boot0.rom or MRA (required)
 localparam DRV_ADDR = 25'h0080000;  // Drive ROM: 512k                       loaded from boot0.rom, boot1.rom or MRA (required)
-localparam CRT_ADDR = 25'h0100000;  // Cartridge: 1M                         can be loaded from boot0.rom, boot3.rom or MRA (first 32k, optional)
-localparam IFR_ADDR = 25'h0200000;  // Internal function ROM: 1M             can be loaded from boot2.rom or MRA (optional)
-localparam TAP_ADDR = 25'h0300000;  // Tape buffer (not aligned)
+localparam CRT_ADDR = 25'h0100000;  // Cartridge: 2M (up 128 banks x 16 KB)  can be loaded from boot0.rom, boot3.rom or MRA (first 32k, optional)
+localparam IFR_ADDR = 25'h0300000;  // Internal function ROM: 1M             can be loaded from boot2.rom or MRA (optional)
+localparam TAP_ADDR = 25'h0400000;  // Tape buffer (not aligned)
 localparam GEO_ADDR = 25'h0C00000;  // GeoRAM: 4M
 localparam REU_ADDR = 25'h1000000;  // REU: 16M
 
@@ -1747,14 +1747,16 @@ end
 
 wire ext_iec_en = status[25];
 
+// Gestione IEC wired‑OR (come nel core C64)
 wire ext_iec_clk  = |snac_mode ? 1'b1 : (USER_IN[2] | ~ext_iec_en);
 wire ext_iec_data = |snac_mode ? 1'b1 : (USER_IN[4] | ~ext_iec_en);
 wire ext_iec_srq_n = |snac_mode ? 1'b1 : (USER_IN[6] | ~ext_iec_en);
 
-assign c64_iec_clk_i = ext_iec_clk;
-assign c64_iec_data_i = ext_iec_data;
+assign c64_iec_clk_i   = ext_iec_clk;
+assign c64_iec_data_i  = ext_iec_data;
 assign c64_iec_srq_n_i = ext_iec_srq_n;
 
+// Uscite verso i pin USER_OUT: quando SNAC è attivo, disabilitiamo le uscite IEC (1)
 assign USER_OUT[2] = |snac_mode ? 1'b1 : ((c64_iec_clk_o & drive_iec_clk_o) | ~ext_iec_en);
 assign USER_OUT[3] = |snac_mode ? 1'b1 : ((reset_n & ~status[6]) | ~ext_iec_en);
 assign USER_OUT[4] = |snac_mode ? 1'b1 : ((c64_iec_data_o & drive_iec_data_o) | ~ext_iec_en);

--- a/c128.sv
+++ b/c128.sv
@@ -302,7 +302,7 @@ localparam CONF_STR = {
    "-;",
    "O[3],Swap Joysticks,No,Yes;",
    "O[104:103],SNAC Joystick,Disabled,Joy 1,Joy 2,Joy 1 + 2;",
-   "O[88:87],SNAC Autofire,Off,Slow,Fast;",
+   "O[106:105],SNAC Autofire,Off,Slow,Fast;",
    "-;",
    "O[49:48],8502 Speed,Standard,x2,x3,x4;",
    "HCO[101],Z80 Speed,Standard,x2;",
@@ -456,7 +456,7 @@ wire [6:0] snac_joy  = {1'b0, ~USER_IN[6], ~USER_IN[2], ~USER_IN[3], ~USER_IN[5]
 
 // SNAC Autofire: oscillatore software, non richiede il +5V hardware (DB9 Pin 5)
 // Fire 1 (DB9 Pin 6) viene modulato; Fire 2 (DB9 Pin 9) passa sempre diretto
-wire [1:0] snac_af_mode = status[88:87];
+wire [1:0] snac_af_mode = status[106:105];
 reg [21:0] snac_af_cnt;
 always @(posedge clk_sys) snac_af_cnt <= snac_af_cnt + 1'd1;
 // Slow ~7.6 Hz | Fast ~15.3 Hz  (clk_sys = 32 MHz)
@@ -871,9 +871,9 @@ localparam RAM_ADDR = 25'h0000000;  // System RAM: 256k
 localparam CRM_ADDR = 25'h0040000;  // Cartridge RAM: 64k
 localparam ROM_ADDR = 25'h0060000;  // System ROM: 72k (align on 128k)       loaded from boot0.rom or MRA (required)
 localparam DRV_ADDR = 25'h0080000;  // Drive ROM: 512k                       loaded from boot0.rom, boot1.rom or MRA (required)
-localparam CRT_ADDR = 25'h0100000;  // Cartridge: 2M                         can be loaded from boot0.rom, boot3.rom or MRA (first 32k, optional)
-localparam IFR_ADDR = 25'h0300000;  // Internal function ROM: 1M             can be loaded from boot2.rom or MRA (optional)
-localparam TAP_ADDR = 25'h0400000;  // Tape buffer (not aligned)
+localparam CRT_ADDR = 25'h0100000;  // Cartridge: 1M                         can be loaded from boot0.rom, boot3.rom or MRA (first 32k, optional)
+localparam IFR_ADDR = 25'h0200000;  // Internal function ROM: 1M             can be loaded from boot2.rom or MRA (optional)
+localparam TAP_ADDR = 25'h0300000;  // Tape buffer (not aligned)
 localparam GEO_ADDR = 25'h0C00000;  // GeoRAM: 4M
 localparam REU_ADDR = 25'h1000000;  // REU: 16M
 

--- a/rtl/cartridge.sv
+++ b/rtl/cartridge.sv
@@ -76,15 +76,15 @@ module cartridge
 );
 
 reg        bank_lo_en;
-reg  [6:0] bank_lo;
+reg  [7:0] bank_lo;
 reg        bank_hi_en;
-reg  [6:0] bank_hi;
+reg  [7:0] bank_hi;
 reg [13:0] mask_lo;
 reg  [5:0] bank_no;
 
 reg [13:0] geo_bank;
-reg  [6:0] IOE_bank;
-reg  [6:0] IOF_bank;
+reg  [7:0] IOE_bank;
+reg  [7:0] IOF_bank;
 reg        IOE_wr_ena;
 reg        IOF_wr_ena;
 
@@ -93,12 +93,12 @@ reg        game_overide;
 assign     {exrom, game} = force_ultimax ? 2'b10 : {exrom_overide, game_overide};
 
 // C64 cart: 64 banks of 8K, C128 cart: 32 banks of 16K
-(* ramstyle = "logic" *) reg [6:0] lobanks[0:63];
-(* ramstyle = "logic" *) reg [6:0] hibanks[0:63];
+(* ramstyle = "logic" *) reg [6:0] lobanks[0:127];
+(* ramstyle = "logic" *) reg [6:0] hibanks[0:127];
 
 reg  [7:0] bank_cnt;
-reg [63:0] lobanks_map;
-reg [63:0] hibanks_map;
+reg [127:0] lobanks_map;
+reg [127:0] hibanks_map;
 always @(posedge clk32) begin
 	reg old_loading;
 	old_loading <= cart_loading;
@@ -110,14 +110,14 @@ always @(posedge clk32) begin
 	end
 	if(cart_bank_wr) begin
 		bank_cnt <= bank_cnt + 1'd1;
-		if(cart_bank_num<64) begin
+		if(cart_bank_num<128) begin
 			if(cart_bank_laddr <= 'h8000) begin
-				lobanks[cart_bank_num[5:0]] <= cart_bank_raddr[19:13];
+				lobanks[cart_bank_num[6:0]] <= cart_bank_raddr[19:13];
 				lobanks_map[cart_bank_num[5:0]] <= 1;
 				if(cart_bank_size > 'h2000) hibanks[cart_bank_num[5:0]] <= cart_bank_raddr[19:13]+1'd1;
 			end
 			else begin
-				hibanks[cart_bank_num[5:0]] <= cart_bank_raddr[19:13];
+				hibanks[cart_bank_num[6:0]] <= cart_bank_raddr[19:13];
 				hibanks_map[cart_bank_num[5:0]] <= 1;
 			end
 		end
@@ -864,7 +864,7 @@ always @(posedge clk32) begin
 					end
 				end
 
-			// BMP-Data Turbo 2000, (game=0, exrom=0, one 16k bank)
+					// BMP-Data Turbo 2000, (game=0, exrom=0, one 16k bank)
 			83: begin
 					bank_lo <= 0;
 					bank_hi <= 0;
@@ -875,6 +875,22 @@ always @(posedge clk32) begin
 					else if(iof_wr) begin
 						game_overide  <= 1;
 						exrom_overide <= 1;
+					end
+				end
+
+			// Magic Desk 2 (16k banks, up to 2MB) - game=0, exrom=0
+			85: begin
+					if(!init_n) begin
+						game_overide  <= 0;
+						exrom_overide <= 0;
+						bank_lo       <= 0;
+						bank_hi       <= 1;
+					end
+					else if(ioe_wr) begin
+						bank_lo       <= {data_in[6:0], 1'b0};
+						bank_hi       <= {data_in[6:0], 1'b1};
+						game_overide  <= data_in[7];
+						exrom_overide <= data_in[7];
 					end
 				end
 
@@ -929,11 +945,11 @@ assign mem_ce_out = mem_ce | (cs_ioe & stb_ioe) | (cs_iof & stb_iof);
 //RAM banks are mapped to 0x040000 (64K max)
 //CRT/EFR banks are mapped to 0x100000 (1MB max)
 function [11:0] get_bank;
-	input [6:0] bank;
+	input [7:0] bank;
 	input       ram;
 	input       addr13;
 begin
-	get_bank = ram ? {9'(CRM_ADDR>>16), bank[2:0]} : (c128_n ? {5'(CRT_ADDR>>20), bank[6:0]} : {5'(CRT_ADDR>>20), bank[5:0], addr13});
+	get_bank = ram ? {9'(CRM_ADDR>>16), bank[2:0]} : (c128_n ? ((CRT_ADDR>>13) + bank) : {5'(CRT_ADDR>>20), bank[5:0], addr13});
 end
 endfunction
 


### PR DESCRIPTION
This is only support for Magic Desk 2 2 MB CRT (no Snac support here)
Tested 1541, 1571 and 1581 internal drives (8 and 9), TAP, CRT and PRG files
Tested 1541 external drive via Snac IEC
There is still a bug (present from official RBF) on cursor keys not working on C64 mode. 